### PR TITLE
Local Dev Changes and/or Deployed Assistants Update After Find

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Keep A Changelog!
+
+See this http://keepachangelog.com link for information on how we want this documented formatted.
+
+## v1.0.1
+
+### Fixed
+
+- Assistant init updates configs after find by name or id.
+
+## v1.0.0
+
+### Added
+
+- Initial Release

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![npm](https://img.shields.io/npm/v/experts?logo=npm&color=yellow)](https://www.npmjs.com/package/experts) [![Test](https://github.com/metaskills/experts/actions/workflows/test.yml/badge.svg)](https://github.com/metaskills/experts/actions/workflows/test.yml)
+
 # Multi AI Agent Systems <br>using OpenAI's Assistants API (Experts.js)
 
 ![Experts.js](docs/images/logo.png)

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ const assistant = await MyAssistant.create();
 The Experts.js async `create()` function will: 
 
 * Find or create your assistant by name.
-* Updates the assistants configurations to latest. [(pending)](https://github.com/metaskills/experts/issues/2)
+* Updates the assistants configurations to latest.
 
 ### Simple Ask Interface
 
@@ -81,7 +81,7 @@ const output = await assistant.ask({ role: "user", content: "..." }, threadID);
 
 ### Adding Tools
 
-Normal OpenAI [tools and function calling](https://platform.openai.com/docs/assistants/tools/function-calling) are supported via our constructors options object via `tools` and `tool_resources`. Experts.js also supports adding [Assistants](#assistants) as Tools. More information on using Assistants as [Tools](#tools) can be found in the next section. Use the `addAssistantTool` function to add an Assistant as a Tool.
+Normal OpenAI [tools and function calling](https://platform.openai.com/docs/assistants/tools/function-calling) are supported via our constructors options object via `tools` and `tool_resources`. Experts.js also supports adding [Assistants](#assistants) as Tools. More information on using Assistants as [Tools](#tools) can be found in the next section. Use the `addAssistantTool` function to add an Assistant as a Tool. This must happen after `super()` in your Assistant's constructor.
 
 ```javascript
 class MainAssistant extends Assistant {
@@ -97,8 +97,7 @@ class MainAssistant extends Assistant {
 
 ### Streaming & Events
 
-By default all Experts.js leverages the [Assistants Streaming Events](https://platform.openai.com/docs/api-reference/assistants-streaming/events). These allow your applications to receive text, image, and tool outputs via OpenAI's server-send events. We lever the [openai-node](https://github.com/openai/openai-node/blob/master/helpers.md) stream helpers and surface these and more so you can be in control of all events in your agentic applications.
-
+By default, Experts.js leverages the [Assistants Streaming Events](https://platform.openai.com/docs/api-reference/assistants-streaming/events). These allow your applications to receive text, image, and tool outputs via OpenAI's server-send events. We leverage [openai-node's](https://github.com/openai/openai-node/blob/master/helpers.md) stream helpers and surface these events along with a few custom ones giving your assistants to tap into the complete lifecycle of a Run.
 
 ```javascript
 const assistant = await MainAssistant.create();
@@ -167,7 +166,7 @@ class EchoTool extends Tool {
 
 As such, Tool class names are important and help OpenAI's models decide which tool to call. So pick a good name for your tool class. For example, `ProductsOpenSearchTool` will be `products_open_search` and clearly helps the model infer along with the tool's description what role it performs.
 
-Tools are added to your [Assistant](#assistants) via the `addAssistantTool` function. This function will add the tool to the assistant's tools array and update the assistant's configuration.
+Tools are added to your [Assistant](#assistants) via the `addAssistantTool` function. This function will add the tool to the assistant's tools array and update the assistant's configuration. This must happen after `super()` in your Assistant's constructor.
 
 ```javascript
 class MainAssistant extends Assistant {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "experts",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "experts",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "eventemitter2": "^6.4.9",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "experts",
-  "version": "0.3.1",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "experts",
-      "version": "0.3.1",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "eventemitter2": "^6.4.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "experts",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "An opinionated panel of experts implementation using OpenAI's Assistants API",
   "type": "module",
   "main": "./src/index.js",

--- a/src/experts/assistant.js
+++ b/src/experts/assistant.js
@@ -278,6 +278,7 @@ class Assistant {
     if (!this.id) return;
     const assistant = await openai.beta.assistants.retrieve(this.id);
     debug(`💁‍♂️  Found by id ${this.agentName} assistant ${this.id}`);
+    await this.#update(assistant);
     return assistant;
   }
 
@@ -286,12 +287,30 @@ class Assistant {
       await openai.beta.assistants.list({ limit: "100" })
     ).data.find((a) => a.name === this.agentName);
     debug(`💁‍♂️  Found by name ${this.agentName} assistant`);
+    await this.#update(assistant);
     return assistant;
   }
 
   async #reCreate() {
     const assistant = (await this.#deleteByName()) || (await this.#create());
     return assistant;
+  }
+
+  async #update(assistant) {
+    if (!assistant) return;
+    await openai.beta.assistants.update(assistant.id, {
+      model: this.model,
+      name: this.agentName,
+      description: this.description,
+      instructions: this.instructions,
+      tools: this.tools,
+      tool_resources: this.tool_resources,
+      metadata: this._metadata,
+      temperature: this.temperature,
+      top_p: this.top_p,
+      response_format: this.response_format,
+    });
+    debug(`💁‍♂️ Updated ${this.agentName} assistant ${assistant.id}`);
   }
 
   async #create() {

--- a/test/experts/assistant.test.js
+++ b/test/experts/assistant.test.js
@@ -13,6 +13,11 @@ beforeEach(() => {
   delete process.env.TEST_ASSISTANT_ID;
 });
 
+test("find by id safely supports not found", async () => {
+  const assistant = await TestAssistant.create({ id: "asst_neverfound" });
+  expect(assistant.id).toMatch(/^asst_/);
+});
+
 test("send images with messages image_file", async () => {
   const path = helperPath("test/fixtures/unremarkable-banner.png");
   const file = await openai.files.create({

--- a/test/fixtures/noLLMToolAssistant.js
+++ b/test/fixtures/noLLMToolAssistant.js
@@ -35,7 +35,7 @@ class NoLLMToolAssistant extends Assistant {
   constructor() {
     const name = helperName("NoLLMToolAssistant");
     const description = "Answers to messages.";
-    const instructions = `You must route the message in full to your '${AnswerTool.toolName}' tool. Never respond without first using that tool. Never! Ex: When asked what color the sky is, use the '${AnswerTool.toolName}' tool first.`;
+    const instructions = `You must route /tool messages in full to your '${AnswerTool.toolName}' tool. Never respond without first using that tool. Never! Ex: When asked what color the sky is, use the '${AnswerTool.toolName}' tool first.`;
     super(name, description, instructions);
     this.addAssistantTool(AnswerTool);
   }

--- a/test/uat/noLLMTool.test.js
+++ b/test/uat/noLLMTool.test.js
@@ -4,7 +4,10 @@ import { NoLLMToolAssistant } from "../fixtures.js";
 test("using a tool wiht no llm", async () => {
   const assistant = await NoLLMToolAssistant.create();
   const threadID = await helperThreadID();
-  const output = await assistant.ask("What color is the sky today?", threadID);
+  const output = await assistant.ask(
+    "/tool What color is the sky today?",
+    threadID
+  );
   expect(output).toMatch(/red/i);
   expect(output).toMatch(/green/i);
 });


### PR DESCRIPTION
Updating the instructions, description, model, or any other configuration in the modify assistant API should be performed after an assistant is found by name or id during the initialization process. Practical upshot is that local dev changes are reflected. Same would be true if deploying a production workload with updated instructions, model, etc.