### PR TITLE
No Find/Create by Name. Fix Test Fixture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 See this http://keepachangelog.com link for information on how we want this documented formatted.
 
+## v1.1.0
+
+### Changed
+
+Names are no longer unique when assistants are created. This means the find/recreate by name is no longer needed. Recommend if deployments must track a fixed assistant to use the assistant id environment variable.
+
+### Fixed
+
+OpenAI now seems to validate the tool JSON on Assistant create. Fixed a bug in a test fixture where `required` was in the wrong place.
+
 ## v1.0.2
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "experts",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "experts",
-      "version": "1.0.2",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "eventemitter2": "^6.4.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "experts",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "An opinionated panel of experts implementation using OpenAI's Assistants API",
   "type": "module",
   "main": "./src/index.js",

--- a/src/experts/assistant.js
+++ b/src/experts/assistant.js
@@ -52,10 +52,7 @@ class Assistant {
   async init() {
     await this.beforeInit();
     if (!this.llm) return;
-    this.assistant =
-      (await this.#findByID()) ||
-      (await this.#findByName()) ||
-      (await this.#reCreate());
+    this.assistant = (await this.#findByID()) || (await this.#create());
     for (const [_name, tool] of Object.entries(this.experts)) {
       await tool.init();
     }
@@ -285,22 +282,9 @@ class Assistant {
   async #findByID() {
     if (!this.id) return;
     const assistant = await openai.beta.assistants.retrieve(this.id);
+    if (!assistant) return;
     debug(`💁‍♂️  Found by id ${this.agentName} assistant ${this.id}`);
     await this.#update(assistant);
-    return assistant;
-  }
-
-  async #findByName() {
-    const assistant = (
-      await openai.beta.assistants.list({ limit: "100" })
-    ).data.find((a) => a.name === this.agentName);
-    debug(`💁‍♂️  Found by name ${this.agentName} assistant`);
-    await this.#update(assistant);
-    return assistant;
-  }
-
-  async #reCreate() {
-    const assistant = (await this.#deleteByName()) || (await this.#create());
     return assistant;
   }
 

--- a/test/experts/assistant.test.js
+++ b/test/experts/assistant.test.js
@@ -84,14 +84,11 @@ test("send multiple messages as true message objects", async () => {
 });
 
 test("can use environment variables to find an assistant by id", async () => {
-  const assistant = await TestIDAssistant.create();
-  // Will find the same assistant by name.
-  const assistant2 = await TestIDAssistant.create();
-  expect(assistant.id).toBe(assistant2.id);
+  const assistant1 = await TestIDAssistant.create();
   // Will find by id.
-  process.env.TEST_ASSISTANT_ID = assistant2.id;
-  const assistant3 = await TestIDAssistant.create();
-  expect(assistant2.id).toBe(assistant3.id);
+  process.env.TEST_ASSISTANT_ID = assistant1.id;
+  const assistant2 = await TestIDAssistant.create();
+  expect(assistant2.id).toBe(assistant1.id);
 });
 
 test("can configure various options", async () => {
@@ -122,7 +119,7 @@ test("can configure various options", async () => {
 
 test("create new assistant using name, description, and instruction defaults", async () => {
   // None exists before creation.
-  const name = helperName("Test");
+  const name = helperName("Test") + Math.random().toString().substring(2, 10);
   TestAssistant.name = name;
   const assistantNone = await helperFindAssistant(name);
   expect(assistantNone).toBeUndefined();

--- a/test/fixtures/productsOpenSearchTool.js
+++ b/test/fixtures/productsOpenSearchTool.js
@@ -29,7 +29,6 @@ class ProductsOpenSearchTool extends Tool {
               properties: { message: { type: "string" } },
               required: ["message"],
             },
-            required: ["message"],
           },
         },
       ],

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -10,7 +10,7 @@ const helperName = (use, options = {}) => {
   const rand = options.rand !== undefined ? options.rand : true;
   const name = `Experts.js (${use})`;
   if (!rand) return name;
-  return `${name} ${Math.random().toString(36).substring(4)}`;
+  return name;
 };
 
 const helperPath = (filePath) => {


### PR DESCRIPTION
## Changed

Names are no longer unique when assistants are created. This means the find/recreate by name is no longer needed. Recommend if deployments must track a fixed assistant to use the assistant id environment variable.

## Fixed

OpenAI now seems to validate the tool JSON on Assistant create. Fixed a bug in a test fixture where `required` was in the wrong place.