### PR TITLE
Major Assistant & Tool Constructor Changes & Deployment Options v1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 See this http://keepachangelog.com link for information on how we want this documented formatted.
 
+## v1.2.0
+
+### Changed
+
+**Major Assistant & Tool Constructor Changes**
+
+Both Assistant & Tool have removed their (name, description, instructions) ordinal parameters in favor a single options object. 
+
+```javascript
+// Using Assistant.create() factory.
+// 
+assistant = new Assistant.craete({
+  name: "My Assistant",
+  instructions: "My Assistant Instructions",
+  ...
+});
+
+// Or using ES6 Classes.
+//
+class MyAssistant extends Assistant {
+  constructor() {
+    super({
+      name: "My Assistant",
+      instructions: "My Assistant Instructions",
+    });
+  }
+})
+```
+
 ## v1.1.0
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ See this http://keepachangelog.com link for information on how we want this docu
 
 **Major Assistant & Tool Constructor Changes**
 
-Both Assistant & Tool have removed their (name, description, instructions) ordinal parameters in favor a single options object. 
+Both Assistant & Tool have removed their (name, description, instructions) ordinal parameters in favor a single options object. Now, the constructor signature is:
 
 ```javascript
 // Using Assistant.create() factory.
@@ -30,6 +30,10 @@ class MyAssistant extends Assistant {
   }
 })
 ```
+
+## Added
+
+A new `skipUpdate` option to use for deployments such as staging where it might be desirable to use the Assistants remote resource instructions or other properties.
 
 ## v1.1.0
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,8 @@ const assistant = Assistant.create({
 });
 ```
 
-Creating assistants without an `id` parameter will always create a new assistant.
+> [!IMPORTANT]  
+> Creating assistants without an `id` parameter will always create a new assistant. See our [deployment](#deployment) section for more information.
 
 ### Simple Ask Interface
 
@@ -397,6 +398,23 @@ class MyAssistant extends Assistant {
   }
 }
 ```
+
+## Deployments
+
+In order for an Assistant to be deployed to a production environment, we recommend the following configurations. First, create or find your assistant's id. The string will be in the format of `asst_abc123`. Then pass this id into the Assistant's or Tools's constructor. This will ensure that the same assistant is used across all deployments.
+
+```javascript
+class MyAssistant extends Assistant {
+  constructor() {
+    super({
+      // ...
+      id: process.env.MY_ASSISTANT_ID
+    });
+  }
+}
+```
+
+Once an Assistant or Tool is found by id, any remote configurations that are different present are overwritten by the local configurations. If required, for example in a staging environment, you can bypass this behavior by setting the `skipUpdate` option to `true`.
 
 ## Environment Variables
 

--- a/README.md
+++ b/README.md
@@ -13,8 +13,10 @@ The new Assistants API from OpenAI sets a new industry standard, significantly a
 Experts.js aims to simplify the usage of this new API by removing the complexity of managing [Run](https://platform.openai.com/docs/assistants/how-it-works/runs-and-run-steps) objects and allowing Assistants to be linked together as Tools.
 
 ```javascript
+import { Assistant, Thread } from "experts";
+
 const thread = await Thread.create();
-const assistant = await MyAssistant.create();
+const assistant = await Assistant.create();
 const output = await assistant.ask("Say hello.", thread.id);
 console.log(output) // Hello
 ```
@@ -46,11 +48,10 @@ The constructor of our [Assistant](https://platform.openai.com/docs/assistants/h
 ```javascript
 class MyAssistant extends Assistant {
   constructor() {
-    const name = "My Assistant";
-    const description = "...";
-    const instructions = "..."
-    super(name, description, instructions, {
-      model: "gpt-4-turbo",
+    super({
+      name: "My Assistant",
+      instructions: "...",
+      model: "gpt-4o",
       tools: [{ type: "file_search" }],
       temperature: 0.1,
       tool_resources: {
@@ -65,10 +66,17 @@ class MyAssistant extends Assistant {
 const assistant = await MyAssistant.create();
 ```
 
-The Experts.js async `create()` function will: 
+The Experts.js async `Assistant.create()` base factory function is a simple way to create an assistant using the same constructor options.
 
-* Find or create your assistant by name.
-* Updates the assistants configurations to latest.
+```javascript
+const assistant = Assistant.create({
+  name: "My Assistant",
+  instructions: "...",
+  model: "gpt-4o",
+});
+```
+
+Creating assistants without an `id` parameter will always create a new assistant.
 
 ### Simple Ask Interface
 
@@ -86,10 +94,10 @@ Normal OpenAI [tools and function calling](https://platform.openai.com/docs/assi
 ```javascript
 class MainAssistant extends Assistant {
   constructor() {
-    const name = "Company Assistant;
-    const description = "...";
-    const instructions = "...";
-    super(name, description, instructions);
+    super({
+      name: "Company Assistant",
+      instructions: "...",
+    });
     this.addAssistantTool(ProductsTools);
   }
 }
@@ -138,10 +146,9 @@ Using an [Assistant](#assistants) as a Tool is central focal point of the Expert
 ```javascript
 class EchoTool extends Tool {
   constructor() {
-    const name = "Echo Tool";
-    const description = "Echo";
-    const instructions = "Echo the same text back to the user";
-    super(name, description, instructions, {
+    super({
+      name: "Echo Tool",
+      instructions: "Echo the same text back to the user",
       parentsTools: [
         {
           type: "function",
@@ -171,10 +178,10 @@ Tools are added to your [Assistant](#assistants) via the `addAssistantTool` func
 ```javascript
 class MainAssistant extends Assistant {
   constructor() {
-    const name = "Company Assistant;
-    const description = "...";
-    const instructions = "...";
-    super(name, description, instructions);
+    super({
+      name: "Company Assistant",
+      instructions: "..."
+    });
     this.addAssistantTool(EchoTool);
   }
 }
@@ -189,8 +196,8 @@ By default Tools are backed by an LLM `model` and perform all the same lifecycle
 ```javascript
 class AnswerTwoTool extends Tool {
   constructor() {
-    // ...
-    super(name, description, instructions, {
+    super({
+      // ...
       llm: false,
       parentsTools: [...],
     });
@@ -217,8 +224,8 @@ Alternatively, LLM backed Tools could opt to redirect their own tool outputs bac
 ```javascript
 class ProductsTool extends Tool {
   constructor() {
-    // ...
-    super(name, description, instructions, {
+    super({
+      // ...
       temperature: 0.1,
       tools: [{ type: "code_interpreter" }],
       outputs: "tools",
@@ -269,8 +276,8 @@ First, you can specify `run_options` in the Assistant's constructor. These optio
 ```javascript
 class CarpenterAssistant extends Assistant {
   constructor() {
-    // ...
-    super(name, description, instructions, {
+    super({
+      // ...
       run_options: {
         tool_choice: {
           type: "function",
@@ -353,10 +360,9 @@ Using a [Vector Store](https://platform.openai.com/docs/assistants/tools/file-se
 
 class VectorSearchAssistant extends Assistant {
   constructor() {
-    const name = "Vector Search Assistant";
-    const description = "...";
-    const instructions = "..."
-    super(name, description, instructions, {
+    super({
+      name: "Vector Search Assistant",
+      instructions: "...",
       tools: [{ type: "file_search" }],
       temperature: 0.1,
       tool_resources: {
@@ -376,8 +382,9 @@ Using the [Streaming & Events](#streaming--events) feature to report token usage
 ```javascript
 class MyAssistant extends Assistant {
   constructor() {
-    // ...
-    super(name, description, instructions);
+    super({
+      // ...
+    });
     this.on("runStepDone", this.#reportUsage.bind(this));
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "experts",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "experts",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
         "eventemitter2": "^6.4.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "experts",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "An opinionated panel of experts implementation using OpenAI's Assistants API",
   "type": "module",
   "main": "./src/index.js",

--- a/src/experts/assistant.js
+++ b/src/experts/assistant.js
@@ -19,16 +19,16 @@ class Assistant {
   #expertsOutputs = [];
   #asyncListeners = {};
 
-  static async create() {
-    const asst = new this();
+  static async create(options = {}) {
+    const asst = new this(options);
     await asst.init();
     return asst;
   }
 
-  constructor(agentName, description, instructions, options = {}) {
-    this.agentName = agentName;
-    this.description = description;
-    this.instructions = instructions;
+  constructor(options = {}) {
+    this.name = options.name;
+    this.description = options.description;
+    this.instructions = options.instructions;
     this.llm = options.llm !== undefined ? options.llm : true;
     if (this.llm) {
       this.id = options.id;
@@ -70,6 +70,10 @@ class Assistant {
 
   get metadata() {
     return this.assistant.metadata;
+  }
+
+  get nameOrID() {
+    return this.name || this.id;
   }
 
   // Interface
@@ -155,7 +159,7 @@ class Assistant {
       }
     } else {
       if (!thread.hasAssistantMetadata) {
-        thread.addMetaData({ assistant: this.agentName });
+        thread.addMetaData({ assistant: this.nameOrID });
       }
     }
     return thread;
@@ -281,9 +285,14 @@ class Assistant {
 
   async #findByID() {
     if (!this.id) return;
-    const assistant = await openai.beta.assistants.retrieve(this.id);
+    let assistant;
+    try {
+      assistant = await openai.beta.assistants.retrieve(this.id);
+    } catch (error) {
+      if (error.status !== 404) throw error;
+    }
     if (!assistant) return;
-    debug(`💁‍♂️  Found by id ${this.agentName} assistant ${this.id}`);
+    debug(`💁‍♂️  Found by id ${this.nameOrID}assistant ${this.id}`);
     await this.#update(assistant);
     return assistant;
   }
@@ -292,7 +301,7 @@ class Assistant {
     if (!assistant) return;
     await openai.beta.assistants.update(assistant.id, {
       model: this.model,
-      name: this.agentName,
+      name: this.nameOrID,
       description: this.description,
       instructions: this.instructions,
       tools: this.tools,
@@ -302,13 +311,13 @@ class Assistant {
       top_p: this.top_p,
       response_format: this.response_format,
     });
-    debug(`💁‍♂️ Updated ${this.agentName} assistant ${assistant.id}`);
+    debug(`💁‍♂️ Updated ${this.nameOrID} assistant ${assistant.id}`);
   }
 
   async #create() {
     const assistant = await openai.beta.assistants.create({
       model: this.model,
-      name: this.agentName,
+      name: this.nameOrID,
       description: this.description,
       instructions: this.instructions,
       temperature: this.temperature,
@@ -318,18 +327,8 @@ class Assistant {
       metadata: this._metadata,
       response_format: this.response_format,
     });
-    debug(`💁‍♂️ Created ${this.agentName} assistant ${assistant.id}`);
+    debug(`💁‍♂️ Created ${this.nameOrID} assistant ${assistant.id}`);
     return assistant;
-  }
-
-  async #deleteByName() {
-    const assistant = (
-      await openai.beta.assistants.list({ limit: 100 })
-    ).data.find((a) => a.name === this.agentName);
-    if (assistant !== undefined) {
-      debug(`🗑️  Deleting assistant: ${this.agentName}`);
-      await openai.beta.assistants.del(assistant.id);
-    }
   }
 }
 

--- a/src/experts/assistant.js
+++ b/src/experts/assistant.js
@@ -44,6 +44,8 @@ class Assistant {
       this._metadata = options.metadata;
       this.response_format = options.response_format || "auto";
       this.run_options = options.run_options || {};
+      this.skipUpdate =
+        options.skipUpdate !== undefined ? options.skipUpdate : false;
       this.emitter = new EventEmitter2({ maxListeners: 0, newListener: true });
       this.emitter.on("newListener", this.#newListener.bind(this));
     }
@@ -298,7 +300,7 @@ class Assistant {
   }
 
   async #update(assistant) {
-    if (!assistant) return;
+    if (!assistant || this.skipUpdate) return;
     await openai.beta.assistants.update(assistant.id, {
       model: this.model,
       name: this.nameOrID,

--- a/src/experts/thread.js
+++ b/src/experts/thread.js
@@ -50,7 +50,7 @@ class Thread {
     if (!threadID) {
       thread = await Thread.create();
       await this.addMetaData({ [threadKey]: thread.id });
-      await thread.addMetaData({ tool: tool.agentName });
+      await thread.addMetaData({ tool: tool.nameOrID });
     } else {
       thread = await Thread.find(threadID);
     }

--- a/src/experts/tool.js
+++ b/src/experts/tool.js
@@ -11,8 +11,8 @@ class Tool extends Assistant {
     return name;
   }
 
-  constructor(agentName, description, instructions, options = {}) {
-    super(agentName, description, instructions, options);
+  constructor(options = {}) {
+    super(options);
     this.isTool = true;
     this.hasThread = options.hasThread !== undefined ? options.hasThread : true;
     this.outputs = options.outputs || "default";

--- a/test/experts/assistant.test.js
+++ b/test/experts/assistant.test.js
@@ -97,7 +97,7 @@ test("can configure various options", async () => {
     file: fs.createReadStream(path),
     purpose: "assistants",
   });
-  const assistant = await TestAssistant.createWithOptions({
+  const assistant = await TestAssistant.create({
     metadata: { foo: "bar" },
     temperature: 0.5,
     top_p: 0.5,
@@ -126,7 +126,7 @@ test("create new assistant using name, description, and instruction defaults", a
   const assistant = await TestAssistant.create();
   const backendAssistant = await helperFindAssistant(name);
   // Assistant
-  expect(assistant.agentName).toBe(name);
+  expect(assistant.nameOrID).toBe(name);
   expect(assistant.description).toBe("test-description");
   expect(assistant.instructions).toBe("test-instructions");
   expect(assistant.llm).toBe(true);
@@ -148,10 +148,10 @@ test("create new assistant using name, description, and instruction defaults", a
 
 test("assistants store metadata in the thread", async () => {
   const threadID = await helperThreadID();
-  const assistant = await TestAssistant.createWithOptions({
+  const assistant = await TestAssistant.create({
     instructions: "Only say hello.",
   });
   await assistant.ask("Hello", threadID);
   const thread = await Thread.find(threadID);
-  expect(thread.metadata.assistant).toBe(assistant.agentName);
+  expect(thread.metadata.assistant).toBe(assistant.nameOrID);
 });

--- a/test/fixtures/dataTool.js
+++ b/test/fixtures/dataTool.js
@@ -5,10 +5,9 @@ import { Tool } from "../../src/experts/tool.js";
 
 class DataTool extends Tool {
   constructor() {
-    const name = helperName("DataTool");
-    const description = "Data Tool";
-    const instructions = "Search your data files for answers to questions.";
-    super(name, description, instructions, {
+    super({
+      name: helperName("DataTool"),
+      instructions: "Search your data files for answers to questions.",
       tools: [{ type: "code_interpreter" }],
       temperature: 0.1,
     });

--- a/test/fixtures/echoAssistant.js
+++ b/test/fixtures/echoAssistant.js
@@ -3,10 +3,11 @@ import { Assistant } from "../../src/experts/assistant.js";
 
 class EchoAssistant extends Assistant {
   constructor() {
-    const name = helperName("Echo");
-    const description = "Echo";
-    const instructions = "Echo the same text back to the user";
-    super(name, description, instructions);
+    super({
+      name: helperName("Echo"),
+      description: "Echo",
+      instructions: "Echo the same text back to the user",
+    });
   }
 }
 

--- a/test/fixtures/echoTool.js
+++ b/test/fixtures/echoTool.js
@@ -3,16 +3,15 @@ import { Tool } from "../../src/experts/tool.js";
 
 class EchoTool extends Tool {
   constructor() {
-    const name = helperName("EchoTool");
-    const description = "Echo";
-    const instructions = "Echo the same text back to the user";
-    super(name, description, instructions, {
+    super({
+      name: helperName("EchoTool"),
+      instructions: "Echo the same text back to the user",
       parentsTools: [
         {
           type: "function",
           function: {
             name: EchoTool.toolName,
-            description: description,
+            description: "Echo",
             parameters: {
               type: "object",
               properties: { message: { type: "string" } },

--- a/test/fixtures/eventedAssistant.js
+++ b/test/fixtures/eventedAssistant.js
@@ -3,10 +3,11 @@ import { Assistant } from "../../src/experts/assistant.js";
 
 class EventedAssistant extends Assistant {
   constructor() {
-    const name = helperName("EventedAssistant");
-    const description = "Echo";
-    const instructions = "Echo the same text back to the user";
-    super(name, description, instructions);
+    super({
+      name: helperName("EventedAssistant"),
+      description: "Echo",
+      instructions: "Echo the same text back to the user",
+    });
     this.myEvents = [];
     this.on("event", this.noOp);
     this.on("end", this.noOp);

--- a/test/fixtures/noLLMToolAssistant.js
+++ b/test/fixtures/noLLMToolAssistant.js
@@ -3,10 +3,10 @@ import { Assistant, Tool } from "../../src/index.js";
 
 class AnswerTool extends Tool {
   constructor() {
-    const name = helperName("NoLLMAnswerTool");
-    const description = "Answers to messages.";
-    const instructions = description;
-    super(name, description, instructions, {
+    super({
+      name: helperName("NoLLMAnswerTool"),
+      description: "Answers to messages.",
+      instructions: "Answers to messages.",
       llm: false,
       temperature: 0.1,
       parentsTools: [
@@ -14,7 +14,7 @@ class AnswerTool extends Tool {
           type: "function",
           function: {
             name: AnswerTool.toolName,
-            description: description,
+            description: "Answers to messages.",
             parameters: {
               type: "object",
               properties: { message: { type: "string" } },
@@ -33,10 +33,11 @@ class AnswerTool extends Tool {
 
 class NoLLMToolAssistant extends Assistant {
   constructor() {
-    const name = helperName("NoLLMToolAssistant");
-    const description = "Answers to messages.";
-    const instructions = `You must route /tool messages in full to your '${AnswerTool.toolName}' tool. Never respond without first using that tool. Never! Ex: When asked what color the sky is, use the '${AnswerTool.toolName}' tool first.`;
-    super(name, description, instructions);
+    super({
+      name: helperName("NoLLMToolAssistant"),
+      description: "Answers to messages.",
+      instructions: `You must route /tool messages in full to your '${AnswerTool.toolName}' tool. Never respond without first using that tool. Never! Ex: When asked what color the sky is, use the '${AnswerTool.toolName}' tool first.`,
+    });
     this.addAssistantTool(AnswerTool);
   }
 }

--- a/test/fixtures/oddFactsAssistant.js
+++ b/test/fixtures/oddFactsAssistant.js
@@ -5,10 +5,10 @@ import { helperName, helperPath } from "../helpers.js";
 
 class OddFactsAssistant extends Assistant {
   constructor() {
-    const name = helperName("OddFacts");
-    const description = "Odd Facts";
-    const instructions = "Search your files for answers to questions.";
-    super(name, description, instructions, {
+    super({
+      name: helperName("OddFacts"),
+      description: "Odd Facts",
+      instructions: "Search your files for answers to questions.",
       tools: [{ type: "file_search" }],
       temperature: 0.1,
     });

--- a/test/fixtures/outputsAssistant.js
+++ b/test/fixtures/outputsAssistant.js
@@ -3,17 +3,17 @@ import { Assistant, Tool } from "../../src/index.js";
 
 class AnswerTwoTool extends Tool {
   constructor() {
-    const name = helperName("AnswerTwoTool");
-    const description = "Answers to messages.";
-    const instructions = description;
-    super(name, description, instructions, {
+    super({
+      name: helperName("AnswerTwoTool"),
+      description: "Answers to messages.",
+      instructions: "Answers to messages.",
       llm: false,
       parentsTools: [
         {
           type: "function",
           function: {
             name: AnswerTwoTool.toolName,
-            description: description,
+            description: "Answers to messages.",
             parameters: {
               type: "object",
               properties: { message: { type: "string" } },
@@ -32,10 +32,10 @@ class AnswerTwoTool extends Tool {
 
 class AnswerOneTool extends Tool {
   constructor() {
-    const name = helperName("AnswerOneTool");
-    const description = "Answers to messages.";
-    const instructions = `You must route the message in full to your '${AnswerTwoTool.toolName}' tool. Never respond without first using that tool. Never! Ex: When asked what is my favorite food, use the '${AnswerTwoTool.toolName}' tool first. Lastly, tespond only with the single word 'Success' to the question.`;
-    super(name, description, instructions, {
+    super({
+      name: helperName("AnswerOneTool"),
+      description: "Answers to messages.",
+      instructions: `You must route the message in full to your '${AnswerTwoTool.toolName}' tool. Never respond without first using that tool. Never! Ex: When asked what is my favorite food, use the '${AnswerTwoTool.toolName}' tool first. Lastly, tespond only with the single word 'Success' to the question.`,
       temperature: 0.1,
       outputs: "tools", // THIS: Focus of the test. Combined with only success response.
       parentsTools: [
@@ -43,7 +43,7 @@ class AnswerOneTool extends Tool {
           type: "function",
           function: {
             name: AnswerOneTool.toolName,
-            description: description,
+            description: "Answers to messages.",
             parameters: {
               type: "object",
               properties: { message: { type: "string" } },
@@ -59,10 +59,10 @@ class AnswerOneTool extends Tool {
 
 class OutputsAssistant extends Assistant {
   constructor() {
-    const name = helperName("OutputsAssistant");
-    const description = "Answers to messages.";
-    const instructions = `You must route the message in full to your '${AnswerOneTool.toolName}' tool. Never respond without first using that tool. Never! Ex: When asked what is my favorite food, use the '${AnswerOneTool.toolName}' tool first.`;
-    super(name, description, instructions, {
+    super({
+      name: helperName("OutputsAssistant"),
+      description: "Answers to messages.",
+      instructions: `You must route the message in full to your '${AnswerOneTool.toolName}' tool. Never respond without first using that tool. Never! Ex: When asked what is my favorite food, use the '${AnswerOneTool.toolName}' tool first.`,
       temperature: 0.1,
     });
     this.addAssistantTool(AnswerOneTool);

--- a/test/fixtures/productsAssistant.js
+++ b/test/fixtures/productsAssistant.js
@@ -14,10 +14,10 @@ Follow these rules:
 
 class ProductsAssistant extends Assistant {
   constructor() {
-    const name = helperName("ProductsAssistant");
-    const description = "Product apparel company's virtual assistant.";
-    const instructions = INSTRUCTIONS;
-    super(name, description, instructions, {
+    super({
+      name: helperName("ProductsAssistant"),
+      description: "Product apparel company's virtual assistant.",
+      instructions: INSTRUCTIONS,
       temperature: 0.1,
     });
     this.addAssistantTool(ProductsTool);

--- a/test/fixtures/productsOpenSearchTool.js
+++ b/test/fixtures/productsOpenSearchTool.js
@@ -10,11 +10,11 @@ const INSTRUCTIONS = helperInstructions("productsOpenSearch.md", {
 
 class ProductsOpenSearchTool extends Tool {
   constructor() {
-    const name = helperName("ProductsOpenSearchTool");
-    const description =
-      "Creates a fully formed OpenSearch query based on the user's messages.";
-    const instructions = INSTRUCTIONS;
-    super(name, description, instructions, {
+    super({
+      name: helperName("ProductsOpenSearchTool"),
+      description:
+        "Creates a fully formed OpenSearch query based on the user's messages.",
+      instructions: INSTRUCTIONS,
       temperature: 0.1,
       response_format: { type: "json_object" },
       parentsTools: [

--- a/test/fixtures/productsTool.js
+++ b/test/fixtures/productsTool.js
@@ -18,10 +18,10 @@ Follow these rules:
 
 class ProductsTool extends Tool {
   constructor() {
-    const name = helperName("ProductsTool");
-    const description = "Apparel product search assistant.";
-    const instructions = INSTRUCTIONS;
-    super(name, description, instructions, {
+    super({
+      name: helperName("ProductsTool"),
+      description: "Apparel product search assistant.",
+      instructions: INSTRUCTIONS,
       temperature: 0.1,
       tools: [{ type: "code_interpreter" }],
       outputs: "tools",

--- a/test/fixtures/routerAssistant.js
+++ b/test/fixtures/routerAssistant.js
@@ -4,11 +4,12 @@ import { EchoTool } from "./echoTool.js";
 
 class RouterAssistant extends Assistant {
   constructor() {
-    const name = helperName("Router");
-    const description = "Conversational Router";
-    const instructions =
-      "Routes messages to the right tool. Send any message starting with the /echo command to the echo tool. If no tool can be found for the message, reply with one word 'unrouteable' as the error.";
-    super(name, description, instructions);
+    super({
+      name: helperName("Router"),
+      description: "Conversational Router",
+      instructions:
+        "Routes messages to the right tool. Send any message starting with the /echo command to the echo tool. If no tool can be found for the message, reply with one word 'unrouteable' as the error.",
+    });
     this.addAssistantTool(EchoTool);
   }
 }

--- a/test/fixtures/testAssistant.js
+++ b/test/fixtures/testAssistant.js
@@ -10,22 +10,21 @@ class TestAssistant extends Assistant {
     this._name = value;
   }
 
-  static async createWithOptions(options = {}) {
-    const asst = new this(options);
-    await asst.init();
-    return asst;
-  }
-
   constructor(options = {}) {
-    super(TestAssistant.name, "test-description", "test-instructions", options);
+    options.name = TestAssistant.name;
+    options.description = "test-description";
+    options.instructions = "test-instructions";
+    super(options);
   }
 }
 
 class TestIDAssistant extends Assistant {
   constructor() {
-    const name = helperName("Test", { rand: false });
-    super(name, "test-description", "test-instructions", {
+    super({
       id: process.env.TEST_ASSISTANT_ID,
+      name: helperName("Test", { rand: false }),
+      description: "test-description",
+      instructions: "test-instructions",
     });
   }
 }

--- a/test/fixtures/toolboxAssistant.js
+++ b/test/fixtures/toolboxAssistant.js
@@ -4,16 +4,16 @@ import { Assistant, Tool } from "../../src/index.js";
 class DrillTool extends Tool {
   static calls = 0;
   constructor() {
-    const name = helperName("DrillTool");
-    const description = "A drill tool.";
-    super(name, description, "", {
+    super({
+      name: helperName("DrillTool"),
+      description: "A drill tool.",
       llm: false,
       parentsTools: [
         {
           type: "function",
           function: {
             name: DrillTool.toolName,
-            description: description,
+            description: "A drill tool.",
             parameters: {
               type: "object",
               properties: { use: { type: "boolean" } },
@@ -33,11 +33,11 @@ class DrillTool extends Tool {
 
 class CarpenterAssistant extends Assistant {
   constructor() {
-    const name = helperName("Carpenter");
-    const description = "A carpenter that does not work.";
-    const instructions =
-      "Avoid work at all costs because your drill is broken. But if you did do work, tell me what you did.";
-    super(name, description, instructions, {
+    super({
+      name: helperName("Carpenter"),
+      description: "A carpenter that does not work.",
+      instructions:
+        "Avoid work at all costs because your drill is broken. But if you did do work, tell me what you did.",
       temperature: 0.1,
       run_options: {
         tool_choice: {


### PR DESCRIPTION
Lots of small quality of life changes ( like find by id 404s ) are happening with the Assistant's API. A release out of beta feels like it is coming soon. Time to make some big changes, a huge one is the way our constructor works. When this API was beta, an assistant required a name, description, and instructions. Both Assistants & Tools have removed their (name, description, instructions) ordinal parameters in favor a single options object. Now, the constructor signature is:

```javascript
// Using Assistant.create() factory.
// 
assistant = new Assistant.craete({
  name: "My Assistant",
  instructions: "My Assistant Instructions",
  ...
});

// Or using ES6 Classes.
//
class MyAssistant extends Assistant {
  constructor() {
    super({
      name: "My Assistant",
      instructions: "My Assistant Instructions",
    });
  }
})
```

Now that names are no longer unique. The question of how to treat deployments has come up. Document how to use the `id` parameter to ensure a single assistant is used for a deployment no matter how much horizontal scaling is happing. Otherwise, spinning up new cloud resources such as Lambda instances or K8s pods would result in creating a new assistant for each process. We also support a new `skipUpdate` option that allows for remote configurations to be applied to new running instances. Thus allowing for new resources to leverage the remote configurations, such as model and instructions. Great for zero deployment changes. For example:

```javascript
class MyAssistant extends Assistant {
  constructor() {
    super({
      // ...
      id: process.env.MY_ASSISTANT_ID,
      skipUpdate: process.env.SKIP_UPDATE
    });
  }
}
```