### PR TITLE
Assistants & Tools Can Have Non-Expert Tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 See this http://keepachangelog.com link for information on how we want this documented formatted.
 
+## v1.3.1
+
+### Fixed
+
+Allow Assistants or Assistants as Tools to have OpenAI `tools` that can be invoked on your Run's behalf. Prior, there was a heavy bias that all tool calls were experts and this is not the case.
+
 ## v1.3.0
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "experts",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "experts",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "license": "MIT",
       "dependencies": {
         "eventemitter2": "^6.4.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "experts",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "An opinionated panel of experts implementation using OpenAI's Assistants API",
   "type": "module",
   "main": "./src/index.js",

--- a/src/experts/assistant.js
+++ b/src/experts/assistant.js
@@ -39,6 +39,7 @@ class Assistant {
         options.temperature !== undefined ? options.temperature : 1.0;
       this.top_p = options.top_p !== undefined ? options.top_p : 1.0;
       this.experts = [];
+      this.expertsFunctionNames = [];
       this.tools = options.tools || [];
       this.tool_resources = options.tool_resources || {};
       this._metadata = options.metadata;
@@ -107,7 +108,10 @@ class Assistant {
     this.experts.push(assistantTool);
     if (assistantTool.isParentsTools) {
       for (const tool of assistantTool.parentsTools) {
-        this.tools.push(tool);
+        if (tool.type === "function") {
+          this.tools.push(tool);
+          this.expertsFunctionNames.push(tool.function.name);
+        }
       }
     }
   }

--- a/src/experts/run.js
+++ b/src/experts/run.js
@@ -126,6 +126,7 @@ class Run {
 
   #findExpertByToolName(functionName) {
     let toolCaller;
+    // Always ask an expert if they can answer.
     this.assistant.experts.forEach((expert) => {
       if (expert.isParentsTools) {
         expert.parentsTools.forEach((parentTool) => {
@@ -138,6 +139,15 @@ class Run {
         });
       }
     });
+    if (toolCaller) return toolCaller;
+    // Allow this assistant to use its own tool if that tool is not a linked expert.
+    if (!this.assistant.expertsFunctionNames.includes(functionName)) {
+      this.assistant.tools.forEach((tool) => {
+        if (tool.type === "function" && tool.function.name === functionName) {
+          toolCaller = this.assistant;
+        }
+      });
+    }
     return toolCaller;
   }
 }

--- a/test/fixtures/echoTool.js
+++ b/test/fixtures/echoTool.js
@@ -12,11 +12,11 @@ class EchoTool extends Tool {
           type: "function",
           function: {
             name: "marco",
-            description: "Use this tool if you get the /marco command.",
+            description: "Use this tool if you get the '/marco' message.",
             parameters: {
               type: "object",
-              properties: { invoke: { type: "boolean" } },
-              required: ["invoke"],
+              properties: { invoke_marco: { type: "boolean" } },
+              required: ["invoke_marco"],
             },
           },
         },
@@ -36,12 +36,17 @@ class EchoTool extends Tool {
         },
       ],
     });
+    this.marcoToolCallCount = 0;
   }
 
   async ask(message, threadID, options = {}) {
-    const json = JSON.parse(message);
-    if (json.message === "marco") {
-      return "polo";
+    let json;
+    try {
+      json = JSON.parse(message);
+    } catch (error) {}
+    if (json?.invoke_marco === true) {
+      this.marcoToolCallCount++;
+      return "poolo";
     }
     return await super.ask(message, threadID, options);
   }

--- a/test/fixtures/routerAssistant.js
+++ b/test/fixtures/routerAssistant.js
@@ -7,8 +7,9 @@ class RouterAssistant extends Assistant {
     super({
       name: helperName("Router"),
       description: "Conversational Router",
+      temperature: 0.1,
       instructions:
-        "Routes messages to the right tool. Send any message starting with the /echo or /marco command to the echo tool. If no tool can be found for the message, reply with one word 'unrouteable' as the error.",
+        "Routes messages to the right tool. Send any message starting with the '/echo' or '/marco' command to that tool using the exact message you received. If no tool can be found for the message, reply with one word 'unrouteable' as the error.",
     });
     this.addAssistantTool(EchoTool);
   }

--- a/test/uat/router.test.js
+++ b/test/uat/router.test.js
@@ -24,8 +24,10 @@ test("each has own thread using metadata links", async () => {
   expect(thread2.metadata.tool).toMatch(/Experts\.js \(EchoTool\)/);
 });
 
-test("commands can pass from tool to tool", async () => {
+test("commands can pass from assistant to assistant's tool", async () => {
   const threadID = await helperThreadID();
   const output = await assistant.ask("/marco", threadID);
-  expect(output).toMatch(/polo/);
+  const tool = assistant.experts[0];
+  expect(tool.marcoToolCallCount).toBe(1);
+  expect(output).toMatch(/poolo/);
 });


### PR DESCRIPTION
This was the intention behind #17 but it was not tested really well. The idea is simple, an Assistant or an Assistant as a Tool  can each have their own tools and Experts.js should allow this to happen. Since a Tool provides itself via `parentTools` to the parent, we have to ensure that this tool is not called recursively. So we introduced a new abstraction in the run object and allow finding an expert by looking first at experts tools (child -> parent) then looking for the local tool in the Assistant as long as it is not an expert-backed tool. God we need some more words to describe this all. The test case should highlight what is happening and I think I need to make some diagram later.