### PR TITLE
Cleaner DEBUG=1 Output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 See this http://keepachangelog.com link for information on how we want this document formatted.
 
+## v1.5.8
+
+### Changed
+
+- Modified `debugEvent` function in `src/helpers.js` to remove instructions from event data when logging in DEBUG mode, preventing large instruction strings from cluttering debug output.
+
 ## v1.5.5, v1.5.6, v1.5.7
 
 ### Fixed
@@ -157,3 +163,10 @@ However, not all make sense with Experts.js.
 ### Added
 
 - Initial Release
+
+# Changelog
+
+## [Unreleased]
+
+### Changed
+- Modified `debugEvent` function in `src/helpers.js` to remove instructions from event data when logging in DEBUG mode, preventing large instruction strings from cluttering debug output.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "experts",
-  "version": "1.5.7",
+  "version": "1.5.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "experts",
-      "version": "1.5.7",
+      "version": "1.5.8",
       "license": "MIT",
       "dependencies": {
         "eventemitter2": "^6.4.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "experts",
-  "version": "1.5.7",
+  "version": "1.5.8",
   "description": "An opinionated panel of experts implementation using OpenAI's Assistants API",
   "type": "module",
   "scripts": {

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -10,7 +10,11 @@ const debug = (message) => {
 const debugEvent = (event) => {
   if (!DEBUG) return;
   if (event.event.includes("delta") && !DEBUG_DELTAS) return;
-  debug(`📡 Event: ${JSON.stringify(event)}`);
+  const eventCopy = JSON.parse(JSON.stringify(event));
+  if (eventCopy.data && eventCopy.data.instructions) {
+    eventCopy.data.instructions = "[INSTRUCTIONS REMOVED]";
+  }
+  debug(`📡 Event: ${JSON.stringify(eventCopy)}`);
 };
 
 const messagesContent = (messages) => {


### PR DESCRIPTION
Modified `debugEvent` function in `src/helpers.js` to remove instructions from event data when logging in DEBUG mode, preventing large instruction strings from cluttering debug output.